### PR TITLE
fix: restore mysql socket in check database fucntion

### DIFF
--- a/bin/uptime_wait
+++ b/bin/uptime_wait
@@ -100,8 +100,7 @@ final class UptimeWait
             ];
 
             $dsn = ('localhost' === $dbOptions['host'])
-                    // ? 'mysql:unix_socket=/run/mysqld/mysqld.sock;dbname=' . $dbOptions['dbname']
-                    ? 'mysql:unix_socket=/run/mysqld/mariadbd.sock;dbname=' . $dbOptions['dbname']
+                    ? 'mysql:unix_socket=/run/mysqld/mysqld.sock;dbname=' . $dbOptions['dbname']
                     : 'mysql:host=' . $dbOptions['host'] . ';port=' . $dbOptions['port']
                     . ';dbname=' . $dbOptions['dbname'];
 


### PR DESCRIPTION
It restored mysql socket in `check database` function.